### PR TITLE
Rewrote new_oid() with deterministic behavior

### DIFF
--- a/stfs.c
+++ b/stfs.c
@@ -453,6 +453,7 @@ static int store_chunk(Chunk blocks[NBLOCKS][CHUNKS_PER_BLOCK], Chunk *chunk) {
 
 static uint8_t is_oid_available(Chunk blocks[NBLOCKS][CHUNKS_PER_BLOCK], const uint32_t oid) {
   int b,c;
+  if (oid < 2) return 0;
   for(b=0;b<NBLOCKS;b++) {
     for(c=0;c<CHUNKS_PER_BLOCK;c++) {
       if(blocks[b][c].type==Inode && blocks[b][c].inode.oid == oid) return 0;

--- a/stfs.c
+++ b/stfs.c
@@ -471,7 +471,8 @@ static uint32_t new_oid(Chunk blocks[NBLOCKS][CHUNKS_PER_BLOCK]) {
       }
     }
   }
-  // if execution reaches this, we ran out of OIDs
+  // if execution reaches this, we ran out of OIDs or the FS is empty
+  return 2;
 }
 
 static void del_chunk(Chunk blocks[NBLOCKS][CHUNKS_PER_BLOCK], const uint32_t b, const uint32_t c) {

--- a/stfs.c
+++ b/stfs.c
@@ -453,11 +453,14 @@ static int store_chunk(Chunk blocks[NBLOCKS][CHUNKS_PER_BLOCK], Chunk *chunk) {
 }
 
 static uint32_t new_oid(Chunk blocks[NBLOCKS][CHUNKS_PER_BLOCK]) {
-  // todo port use local random
-  uint32_t oid = random(), b=0, c=0;
-  // probabalistic, might never finish, todo rewrite into deterministic
-  while(oid==0 || find_chunk(blocks, Inode, oid, 0, 0, &b, &c)!=NULL) {
-    oid = random(); // todo use proper random
+  uint32_t oid=1;
+  int b,c;
+  for(b=0;b<NBLOCKS;b++) {
+    for(c=0;c<CHUNKS_PER_BLOCK;c++) {
+      if(blocks[b][c].type==Inode && blocks[b][c].inode.oid>=oid) {
+        oid = blocks[b][c].inode.oid + 1;
+      }
+    }
   }
   return oid;
 }

--- a/stfs.c
+++ b/stfs.c
@@ -55,7 +55,6 @@
 #include <stdint.h>
 #include <string.h> // mem*
 #include <stdio.h>  // printf
-#include <stdlib.h> // random
 #include <fcntl.h>
 #include <unistd.h>
 

--- a/stfs.c
+++ b/stfs.c
@@ -463,12 +463,11 @@ static uint8_t is_oid_available(Chunk blocks[NBLOCKS][CHUNKS_PER_BLOCK], const u
 }
 
 static uint32_t new_oid(Chunk blocks[NBLOCKS][CHUNKS_PER_BLOCK]) {
-  uint32_t oid=1;
   int b,c;
   for(b=0;b<NBLOCKS;b++) {
     for(c=0;c<CHUNKS_PER_BLOCK;c++) {
       if(blocks[b][c].type==Inode) {
-        oid = blocks[b][c].inode.oid + 1;
+        uint32_t oid = blocks[b][c].inode.oid + 1;
         if (is_oid_available(blocks, oid)) return oid;
       }
     }


### PR DESCRIPTION
This change introduces a simple linear algorithm based on `find_chunk` that was called by the previous implementation. It starts from the root inode (`oid=1`) and returns an `oid` that is bigger than all the `oid` values of the inodes in the file system. Obviously, if there's an inode with `oid=0xFFFFFFFF`, this algorithm might return bogus values, so it's work in progress, but I'm interested in your feedback before proceeding further.
