### PR TITLE
Minor fixes to Makefile and stfsfuzz.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ stfs: stfs.o test.o
 check: scan-build flawfinder cppcheck
 
 clean:
-	rm stfs stfs.o afl test.o
+	rm -f stfs afl *.o
 
 scan-build: clean
 	scan-build-3.9 make

--- a/stfsfuzz.py
+++ b/stfsfuzz.py
@@ -2,9 +2,14 @@
 
 import random
 import sys
-from sh import afl
+
+import sh
+afl = sh.Command("./afl");
 from stfs import Chunk
 from binascii import hexlify
+
+
+
 
 ops = ('m', 'l', 'n', 'x', 'o', 'w', 'r', 's', 'c', 'd', 't', 'c', 'c', 'c' )
 dirs=set([''])


### PR DESCRIPTION
Szia!

This patch contains two minor fixes to the Makefile and Python code, which are handy when trying to get started.

1. 'make clean' now removes both object files and succeed when the project is already clean.
2. stfsfuzz.py no longer requires afl to be in $PATH.
